### PR TITLE
Fix Read locks not being able to see data written within same transaction

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -120,6 +120,14 @@ int main(int argc, char **argv) {
         }
     }
     {
+        Timer t("Test read lock reference write transaction can see changes");
+        auto transaction = ecs.StartTransaction<Tecs::Write<Script>>();
+        Tecs::Entity e = transaction.EntitiesWith<Script>()[0];
+        e.Get<Script>(transaction).data[3] = 88;
+        Tecs::Lock<ECS, Tecs::Read<Script>> lock = transaction;
+        Assert(e.Get<Script>(lock).data[3] == 88, "Script data should be set to 88");
+    }
+    {
         Timer t("Test remove while iterating");
         // Read locks can be created after a write lock without deadlock, but not the other way around.
         auto writeLock = ecs.StartTransaction<Tecs::AddRemove>();


### PR DESCRIPTION
Includes a regression test:
```c++
{
        auto transaction = ecs.StartTransaction<Write<A>>();
        Entity e = transaction.EntitiesWith<A>()[0];
        e.Get<A>(transaction) = 42;
        Lock<ECS, Read<Script>> lock = transaction;
        Assert(e.Get<A>(lock) == 42 "The read lock should be able to see the data written by the same transaction");
}
```

This is fixed by including a runtime copy of the transaction permissions so that the correct buffer is used even after downcasting a lock from Write to Read.