### PR TITLE
Multi-component transaction commit race fix

### DIFF
--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -24,19 +24,21 @@ namespace Tecs {
          * Lock this Component type for reading. Multiple readers can hold this lock at once.
          * This function will only block if a writer is in the process of commiting.
          *
-         * RUnlock() must be called exactly once after reading has completed.
+         * ReadUnlock() must be called exactly once after reading has completed.
          */
-        inline void RLock() {
+        inline bool ReadLock(bool block = true) {
             int retry = 0;
             while (true) {
                 uint32_t current = readers;
-                if (writer != WRITER_COMMITING && current != READER_LOCKED) {
+                if (current != READER_LOCKED) {
                     uint32_t next = current + 1;
                     if (readers.compare_exchange_weak(current, next)) {
                         // Lock aquired
-                        return;
+                        return true;
                     }
                 }
+
+                if (!block) return false;
 
                 if (retry++ > TECS_SPINLOCK_RETRY_YIELD) {
                     retry = 0;
@@ -48,7 +50,7 @@ namespace Tecs {
         /**
          * Unlock this Component type from a read lock. Behavior is undefined if RLock() is not called first.
          */
-        inline void RUnlock() {
+        inline void ReadUnlock() {
             readers--;
         }
 
@@ -57,18 +59,20 @@ namespace Tecs {
          * to hold locks until the write is being committed.
          * This function will block if another writer has already started.
          *
-         * CommitWrite() must be called exactly once after writing has completed.
+         * Once writing has completed CommitLock() must be called exactly once, followed by WriteUnlock().
          */
-        inline void StartWrite() {
+        inline bool WriteLock(bool block = true) {
             int retry = 0;
             while (true) {
                 uint32_t current = writer;
                 if (current == WRITER_FREE) {
-                    if (writer.compare_exchange_weak(current, WRITER_STARTED)) {
+                    if (writer.compare_exchange_weak(current, WRITER_LOCKED)) {
                         // Lock aquired
-                        return;
+                        return true;
                     }
                 }
+
+                if (!block) return false;
 
                 if (retry++ > TECS_SPINLOCK_RETRY_YIELD) {
                     retry = 0;
@@ -84,18 +88,16 @@ namespace Tecs {
          * the changes are applied to the reader buffer.
          *
          * Once the commit is complete, both reader and writer locks will be free.
-         * Behavior is undefined if StartWrite() is not called first.
+         * Behavior is undefined if WriteLock() is not called first.
          */
-        template<bool AllowAddRemove>
-        inline void CommitWrite() {
+        inline void CommitLock() {
             int retry = 0;
             while (true) {
                 uint32_t current = readers;
                 if (current == READER_FREE) {
                     if (readers.compare_exchange_weak(current, READER_LOCKED)) {
                         // Lock aquired
-                        commitEntities<AllowAddRemove>();
-                        break;
+                        return;
                     }
                 }
 
@@ -104,29 +106,14 @@ namespace Tecs {
                     std::this_thread::yield();
                 }
             }
-
-            // Unlock read and write copies
-            readers = READER_FREE;
-            writer = WRITER_FREE;
         }
 
-    private:
-        // Lock states
-        static const uint32_t WRITER_FREE = 0;
-        static const uint32_t WRITER_STARTED = 1;
-        static const uint32_t WRITER_COMMITING = 2;
-        static const uint32_t READER_FREE = 0;
-        static const uint32_t READER_LOCKED = UINT32_MAX;
-
-        std::atomic_uint32_t readers = 0;
-        std::atomic_uint32_t writer = 0;
-
         /**
-         * Copies the write buffer to the read buffer. This should only be called inside CommitWrite().
-         * The valid index list is only copied if AllowAddRemove is true.
+         * Copies the write buffer to the read buffer. This should only be called between CommitLock() and
+         * WriteUnlock(). The valid entity list is only copied if AllowAddRemove is true.
          */
         template<bool AllowAddRemove>
-        inline void commitEntities() {
+        inline void CommitEntities() {
             if (AllowAddRemove) {
                 // The number of components, or list of valid entities may have changed.
                 readComponents = writeComponents;
@@ -143,14 +130,28 @@ namespace Tecs {
             }
         }
 
+        inline void WriteUnlock() {
+            // Unlock read and write copies
+            readers = READER_FREE;
+            writer = WRITER_FREE;
+        }
+
+    private:
+        // Lock states
+        static const uint32_t WRITER_FREE = 0;
+        static const uint32_t WRITER_LOCKED = 1;
+        static const uint32_t READER_FREE = 0;
+        static const uint32_t READER_LOCKED = UINT32_MAX;
+
+        std::atomic_uint32_t readers = 0;
+        std::atomic_uint32_t writer = 0;
+
         std::vector<T> readComponents;
         std::vector<T> writeComponents;
         std::vector<Entity> readValidEntities;
         std::vector<Entity> writeValidEntities;
         std::vector<size_t> validEntityIndexes; // Indexes into writeValidEntities
 
-        template<typename...>
-        friend class ECS;
         template<typename, typename...>
         friend class Lock;
         template<typename, typename...>

--- a/tests/test_ecs.hh
+++ b/tests/test_ecs.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils.hh"
+
 #include <Tecs.hh>
 
 namespace testing {

--- a/tests/utils.hh
+++ b/tests/utils.hh
@@ -54,7 +54,7 @@ namespace testing {
                        << " usec, Avg: " << (total.count() / values.size() / 1000.0)
                        << " usec, P95: " << (values[(size_t)((double)values.size() * 0.95) - 1].count() / 1000.0)
                        << " usec, P99: " << (values[(size_t)((double)values.size() * 0.99) - 1].count() / 1000.0)
-                       << " usec" << std::endl;
+                       << " usec, Total: " << (total.count() / 1000000.0) << " ms" << std::endl;
                 } else if (values.size() == 1) {
                     ss << "[" << name << "] End: " << (values[0].count() / 1000000.0) << " ms" << std::endl;
                 } else {


### PR DESCRIPTION
Fixes https://github.com/xthexder/Tecs/issues/3

A new locking scheme was created to ensure transactions can't start until previous changes for all components are committed.
This introduced a potential for deadlocks while trying to acquire an exclusive lock during commit, which was further solved by making transactions rollback any acquired locks before blocking.