### PR TITLE
Fix possible data race condition with AddRemove and blank transactions

### DIFF
--- a/inc/Tecs_entity.hh
+++ b/inc/Tecs_entity.hh
@@ -40,7 +40,7 @@ namespace Tecs {
         // Alias lock.Exists<Tn...>(e) to allow e.Exists<Tn...>(lock)
         template<typename LockType>
         inline bool Exists(LockType &lock) const {
-            return lock.template Exists(*this);
+            return lock.Exists(*this);
         }
 
         // Alias lock.Has<Tn...>(e) to allow e.Has<Tn...>(lock)

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -126,6 +126,7 @@ namespace Tecs {
             }
             CommitLockInOrder<AllComponentTypes...>();
             if (is_add_remove_allowed<LockType>()) {
+                this->ecs.validIndex.CommitLock();
                 auto &oldBitsets = this->ecs.validIndex.readComponents;
                 auto &bitsets = this->ecs.validIndex.writeComponents;
                 for (size_t id = 0; id < bitsets.size(); id++) {

--- a/tests/utils.hh
+++ b/tests/utils.hh
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace testing {
     static inline void Assert(bool condition, const std::string message) {


### PR DESCRIPTION
This PR adds a test around entity AddRemove transactions and checks various edge cases around transaction commit timing.

This is a fix for a missing CommitLock on `ecs.validIndex`.

Built and tested on Windows MSVC