### PR TITLE
Add Global components

### DIFF
--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -63,7 +63,10 @@ namespace Tecs {
     private:
         using ValidBitset = std::bitset<1 + sizeof...(Tn)>;
         template<typename Event>
-        using ObserverList = std::vector<std::shared_ptr<std::deque<Event>>>;
+        struct ObserverList {
+            std::vector<std::shared_ptr<std::deque<Event>>> observers;
+            std::deque<Event> eventQueue;
+        };
 
         template<size_t I, typename U>
         inline static constexpr size_t GetComponentIndex() {

--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -92,6 +92,8 @@ namespace Tecs {
         }
 
         ComponentIndex<ValidBitset> validIndex;
+        ValidBitset readValidGlobals;
+        ValidBitset writeValidGlobals;
         std::tuple<ComponentIndex<Tn>...> indexes;
         std::deque<Entity> freeEntities;
 

--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -65,7 +65,7 @@ namespace Tecs {
         template<typename Event>
         struct ObserverList {
             std::vector<std::shared_ptr<std::deque<Event>>> observers;
-            std::deque<Event> eventQueue;
+            std::shared_ptr<std::deque<Event>> eventQueue;
         };
 
         template<size_t I, typename U>

--- a/inc/Tecs_locks.hh
+++ b/inc/Tecs_locks.hh
@@ -39,9 +39,26 @@ namespace Tecs {
     struct WriteAll {};
     struct AddRemove {};
 
+    /**
+     * When a component is marked as global by this type trait, it can be accessed without referencing an entity.
+     * Only a single instance of the component will be stored.
+     * 
+     * This type trait can be set using the below pattern:
+     * 
+     * template<>
+     * struct Tecs::is_global_component<ComponentType> : std::true_type {};
+     */
+    template<typename T>
+    struct is_global_component : std::false_type {};
+
     // contains<T, Un...>::value is true if T is part of the set Un...
     template<typename T, typename... Un>
     struct contains : std::disjunction<std::is_same<T, Un>...> {};
+
+    template<typename... Tn>
+    struct contains_global_components : std::disjunction<is_global_component<Tn>...> {};
+    template<typename... Tn>
+    struct all_global_components : std::conjunction<is_global_component<Tn>...> {};
 
     /*
      * Compile time helpers for determining lock permissions.

--- a/inc/Tecs_observer.hh
+++ b/inc/Tecs_observer.hh
@@ -7,6 +7,7 @@
 #include <memory>
 #include <thread>
 #include <tuple>
+#include <type_traits>
 
 namespace Tecs {
     template<typename T>

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -720,8 +720,10 @@ namespace Tecs {
                 auto &validBitset = ecs.validIndex.writeComponents[e.id];
                 if (ecs.template BitsetHas<T>(validBitset)) {
                     validBitset[1 + ecs.template GetComponentIndex<T>()] = false;
-                    size_t validIndex = ecs.template Storage<T>().validEntityIndexes[e.id];
-                    ecs.template Storage<T>().writeValidEntities[validIndex] = Entity();
+                    auto &compIndex = ecs.template Storage<T>();
+                    compIndex.writeComponents[e.id] = {};
+                    size_t validIndex = compIndex.validEntityIndexes[e.id];
+                    compIndex.writeValidEntities[validIndex] = Entity();
                 }
             }
         }
@@ -733,6 +735,7 @@ namespace Tecs {
             auto &validBitset = ecs.writeValidGlobals;
             if (ecs.template BitsetHas<T>(validBitset)) {
                 validBitset[1 + ecs.template GetComponentIndex<T>()] = false;
+                ecs.template Storage<T>().writeComponents[0] = {};
             }
         }
 

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -594,7 +594,7 @@ namespace Tecs {
             return ecs.template Storage<T>().writeComponents[e.id] = value;
         }
 
-        template<typename T, typename... Args>
+        template<typename T, std::enable_if_t<!is_global_component<T>::value, bool> = true, typename... Args>
         inline T &Set(const Entity &e, Args &&...args) const {
             static_assert(is_write_allowed<T, LockType>(), "Component is not locked for writing.");
             static_assert(!is_global_component<T>(), "Global components must be accessed without an Entity");
@@ -636,8 +636,8 @@ namespace Tecs {
             return ecs.template Storage<T>().writeComponents[0] = value;
         }
 
-        template<typename T, typename... Args>
-        inline T &Init(Args &&...args) const {
+        template<typename T, std::enable_if_t<is_global_component<T>::value, bool> = true, typename... Args>
+        inline T &Set(Args &&...args) const {
             static_assert(is_write_allowed<T, LockType>(), "Component is not locked for writing.");
             static_assert(is_global_component<T>(), "Only global components can be accessed without an Entity");
 

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -216,8 +216,6 @@ int main(int argc, char **argv) {
         t = timer3;
     }
 
-    return 0;
-
     {
         {
             auto readLock = ecs.StartTransaction<>();

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -216,6 +216,8 @@ int main(int argc, char **argv) {
         t = timer3;
     }
 
+    return 0;
+
     {
         {
             auto readLock = ecs.StartTransaction<>();

--- a/tests/test_components.hh
+++ b/tests/test_components.hh
@@ -48,4 +48,11 @@ namespace testing {
         Renderable() {}
         Renderable(std::string name) : name(name) {}
     };
+
+    struct GlobalComponent {
+        size_t globalCounter;
+
+        GlobalComponent() : globalCounter(10) {}
+        GlobalComponent(size_t initial_value) : globalCounter(initial_value) {}
+    };
 }; // namespace testing

--- a/tests/test_components.hh
+++ b/tests/test_components.hh
@@ -51,6 +51,7 @@ namespace testing {
 
     struct GlobalComponent {
         size_t globalCounter;
+        std::shared_ptr<bool> test;
 
         GlobalComponent() : globalCounter(10) {}
         GlobalComponent(size_t initial_value) : globalCounter(initial_value) {}

--- a/tests/test_ecs.hh
+++ b/tests/test_ecs.hh
@@ -8,6 +8,10 @@ namespace testing {
     struct Transform;
     struct Renderable;
     struct Script;
+    struct GlobalComponent;
 
-    using ECS = Tecs::ECS<Transform, Renderable, Script>;
+    using ECS = Tecs::ECS<Transform, Renderable, Script, GlobalComponent>;
 }; // namespace testing
+
+template<>
+struct Tecs::is_global_component<testing::GlobalComponent> : std::true_type {};

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -113,13 +113,12 @@ int main(int argc, char **argv) {
         for (size_t i = 0; i < ENTITY_COUNT; i++) {
             Tecs::Entity e = writeLock.NewEntity();
             Assert(e.id == i, "Expected Nth entity id to be " + std::to_string(i) + ", was " + std::to_string(e.id));
-            Assert(!writeLock.Has<Transform, Renderable, Script>(e), "Entity must start with no components");
+            AssertHas<>(writeLock, e);
 
             // Test adding each component type
             Transform value(1.0, 0.0, 0.0, 1);
             writeLock.Set<Transform>(e, value);
-            Assert(writeLock.Has<Transform>(e), "Entity should have a Transform component");
-            Assert(!writeLock.Has<Renderable, Script>(e), "Entity has extra components");
+            AssertHas<Transform>(writeLock, e);
 
             // Test making some changes to ensure values are copied
             value.pos[0] = 2.0;
@@ -127,16 +126,14 @@ int main(int argc, char **argv) {
             transform.pos[0] = 0.0;
 
             writeLock.Set<Renderable>(e, "entity" + std::to_string(i));
-            Assert(writeLock.Has<Transform, Renderable>(e), "Entity should have a Transform and Renderable component");
-            Assert(!writeLock.Has<Script>(e), "Entity has extra components");
+            AssertHas<Transform, Renderable>(writeLock, e);
 
             writeLock.Set<Script>(e, std::initializer_list<uint8_t>({0, 0, 0, 0, 0, 0, 0, 0}));
-            Assert(writeLock.Has<Transform, Renderable, Script>(e), "Entity should have all components");
+            AssertHas<Transform, Renderable, Script>(writeLock, e);
 
             // Test removing a component
             writeLock.Unset<Renderable>(e);
-            Assert(writeLock.Has<Transform, Script>(e), "Entity should have a Transform and Script component");
-            Assert(!writeLock.Has<Renderable>(e), "Entity should not have a Renderable component");
+            AssertHas<Transform, Script>(writeLock, e);
 
             // Test references work after Set()
             auto &script = writeLock.Get<Script>(e);
@@ -151,8 +148,7 @@ int main(int argc, char **argv) {
             Assert(script.data[7] == 0, "Script component should have value [0, 0, 0, 0, 0, 0, 0, (0)]");
 
             writeLock.Set<Script>(e, std::initializer_list<uint8_t>({1, 2, 3, 4}));
-            Assert(writeLock.Has<Transform, Script>(e), "Entity should have a Transform and Script component");
-            Assert(!writeLock.Has<Renderable>(e), "Entity should not have a Renderable component");
+            AssertHas<Transform, Script>(writeLock, e);
 
             Assert(script.data.size() == 4, "Script component should have size 4");
             Assert(script.data[0] == 1, "Script component should have value [(1), 2, 3, 4]");
@@ -195,13 +191,12 @@ int main(int argc, char **argv) {
                 Assert(e.id == ENTITY_COUNT + i,
                     "Expected Nth entity id to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(e.id));
-                Assert(!writeLock.Has<Transform, Renderable, Script>(e), "Entity must start with no components");
+                AssertHas<>(writeLock, e);
 
                 entityList.emplace_back(e);
 
                 writeLock.Set<Transform>(e, 1.0, 3.0, 3.0, 7);
-                Assert(writeLock.Has<Transform>(e), "Entity should have a Transform component");
-                Assert(!writeLock.Has<Renderable, Script>(e), "Entity has extra components");
+                AssertHas<Transform>(writeLock, e);
 
                 // Try setting the value twice in one transaction
                 writeLock.Set<Transform>(e, 3.0, 1.0, 7.0, 3);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         Timer t("Test initializing global components");
         auto writeLock = ecs.StartTransaction<Tecs::AddRemove>();
         Assert(!writeLock.Has<GlobalComponent>(), "ECS must start with no global component");
-        auto &gc = writeLock.Init<GlobalComponent>(0);
+        auto &gc = writeLock.Set<GlobalComponent>(0);
         Assert(writeLock.Has<GlobalComponent>(), "ECS should have a global component");
         Assert(gc.globalCounter == 0, "Global counter should be initialized to zero");
         gc.globalCounter++;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
         auto &gc = writeLock.Get<GlobalComponent>();
         Assert(gc.globalCounter == 1, "Global counter should be read back as 1");
         gc.globalCounter++;
-        
+
         Assert(globalComponentInitialized, "Global component should be initialized");
     }
     {
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
         auto &gc = writeLock.Get<GlobalComponent>();
         Assert(writeLock.Has<GlobalComponent>(), "Get call should have initialized global component");
         Assert(gc.globalCounter == 10, "Global counter should be default initialized to 10");
-        
+
         bool compInitialized = true;
         gc.test = std::shared_ptr<bool>(&compInitialized, [](bool *b) {
             *b = false;
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
         // Try removing the component in the same transaction it was created
         writeLock.Unset<GlobalComponent>();
         Assert(!writeLock.Has<GlobalComponent>(), "Global component should be removed");
-        
+
         Assert(!compInitialized, "Global component should be deconstructed immediately");
     }
     {

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -8,21 +8,21 @@ namespace testing {
     template<typename... Tn, typename LockType>
     static inline void AssertHas(LockType &lock, Tecs::Entity &e) {
         if (Tecs::contains<Transform, Tn...>()) {
-            Assert(lock.Has<Transform>(e), "Entity is missing a Transform component");
+            Assert(lock.template Has<Transform>(e), "Entity is missing a Transform component");
         } else {
-            Assert(!lock.Has<Transform>(e), "Entity should not have a Transform component");
+            Assert(!lock.template Has<Transform>(e), "Entity should not have a Transform component");
         }
         if (Tecs::contains<Renderable, Tn...>()) {
-            Assert(lock.Has<Renderable>(e), "Entity is missing a Renderable component");
+            Assert(lock.template Has<Renderable>(e), "Entity is missing a Renderable component");
         } else {
-            Assert(!lock.Has<Renderable>(e), "Entity should not have a Renderable component");
+            Assert(!lock.template Has<Renderable>(e), "Entity should not have a Renderable component");
         }
         if (Tecs::contains<Script, Tn...>()) {
-            Assert(lock.Has<Script>(e), "Entity is missing a Script component");
+            Assert(lock.template Has<Script>(e), "Entity is missing a Script component");
         } else {
-            Assert(!lock.Has<Script>(e), "Entity should not have a Script component");
+            Assert(!lock.template Has<Script>(e), "Entity should not have a Script component");
         }
-        Assert(lock.Has<Tn...>(e), "Entity is missing components component");
+        Assert(lock.template Has<Tn...>(e), "Entity is missing components component");
     }
 
     void TestReadLock(Tecs::Lock<ECS, Tecs::Read<Transform>> lock);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -5,6 +5,26 @@
 #include <Tecs.hh>
 
 namespace testing {
+    template<typename... Tn, typename LockType>
+    static inline void AssertHas(LockType &lock, Tecs::Entity &e) {
+        if (Tecs::contains<Transform, Tn...>()) {
+            Assert(lock.Has<Transform>(e), "Entity is missing a Transform component");
+        } else {
+            Assert(!lock.Has<Transform>(e), "Entity should not have a Transform component");
+        }
+        if (Tecs::contains<Renderable, Tn...>()) {
+            Assert(lock.Has<Renderable>(e), "Entity is missing a Renderable component");
+        } else {
+            Assert(!lock.Has<Renderable>(e), "Entity should not have a Renderable component");
+        }
+        if (Tecs::contains<Script, Tn...>()) {
+            Assert(lock.Has<Script>(e), "Entity is missing a Script component");
+        } else {
+            Assert(!lock.Has<Script>(e), "Entity should not have a Script component");
+        }
+        Assert(lock.Has<Tn...>(e), "Entity is missing components component");
+    }
+
     void TestReadLock(Tecs::Lock<ECS, Tecs::Read<Transform>> lock);
     void TestWriteLock(Tecs::Lock<ECS, Tecs::Write<Transform>> lock);
     void TestAddRemoveLock(Tecs::Lock<ECS, Tecs::AddRemove> lock);


### PR DESCRIPTION
This PR adds the ability to add single-instance / global components that aren't tied to an Entity (https://github.com/xthexder/Tecs/issues/6)

Several bug fixes are also included for locking issues and component deconstruction (https://github.com/xthexder/Tecs/issues/8)
An optimization was made to observer commits to do more work outside of the commit lock, reducing the critical section time.

A global component can be defined like this:
```c++
namespace ecs {
    struct GlobalComponent {
        int value;

        GlobalComponent() {}
        GlobalComponent(int value) : value(value) {}
    };
}

// Template must be defined in root namespace
template<>
struct Tecs::is_global_component<ecs::GlobalComponent> : std::true_type {};
```

All access to this component can then be done as normal by omitting the Entity:
```c++
{
    auto lock = ecs.StartTransaction<Tecs::AddRemove>();
    lock.Set<GlobalComponent>(42);
}
{
    auto lock = ecs.StartTransaction<Tecs::Write<GlobalComponent>>();
    auto &comp = lock.Get<GlobalComponent>();
    comp.value = 24;
}
{
    auto lock = ecs.StartTransaction<Tecs::Read<GlobalComponent>>();
    const auto &comp = lock.Get<GlobalComponent>();
    Assert(comp.value == 24);
}
```

Observers work identical to non-global components, and will return an event with a null-Entity.