### PR TITLE
Add TECS_HEADER_ONLY option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(Tecs VERSION 0.5.1)
 
+option(TECS_HEADER_ONLY "Use Tecs in header-only library mode" OFF)
+
 # Tell cmake to export a compile_commands.json file
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
@@ -10,7 +12,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Setup compiler flags for various build types
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS                 "/MP /EHsc")
+    set(CMAKE_CXX_FLAGS                 "/MP /EHsc /W4 /WX")
     set(CMAKE_CXX_FLAGS_RELEASE         "/MD /O2")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO  "/MDd /O2")
     set(CMAKE_CXX_FLAGS_DEBUG           "/MDd /DEBUG /ZI /FC")
@@ -30,18 +32,28 @@ endif()
 
 include(GNUInstallDirs)
 
-add_library(${PROJECT_NAME} STATIC src/Tecs.cc)
-target_include_directories(
-    ${PROJECT_NAME}
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
-)
+if(TECS_HEADER_ONLY)
+    add_library(${PROJECT_NAME} INTERFACE)
+    target_include_directories(
+        ${PROJECT_NAME}
+        INTERFACE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+    )
+else()
+    add_library(${PROJECT_NAME} STATIC src/Tecs.cc)
+    target_include_directories(
+        ${PROJECT_NAME}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+    )
+endif()
 
 if(UNIX)
     target_link_libraries(
         ${PROJECT_NAME}
-        PUBLIC
+        INTERFACE
             pthread
     )
 endif()
@@ -56,8 +68,6 @@ install(
 
 # Build tests and examples if we are the root project
 if("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
-    # set(GOOGLETEST_DIR ${EXT_PATH}/googletest/googletest)
-    # add_subdirectory(${EXT_PATH}/googletest)
     add_subdirectory(tests)
     add_subdirectory(examples)
 ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(Tecs VERSION 0.5.1)
 
-option(TECS_HEADER_ONLY "Use Tecs in header-only library mode" OFF)
+option(TECS_HEADER_ONLY "Use Tecs in header-only library mode (Disables nested transaction detection)" OFF)
 
 # Tell cmake to export a compile_commands.json file
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/examples/complex_component.hh
+++ b/examples/complex_component.hh
@@ -6,8 +6,8 @@ namespace example {
             return value;
         }
 
-        void Set(int value) {
-            this->value = value;
+        void Set(int newValue) {
+            this->value = newValue;
             changed = true;
         }
 

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -10,7 +10,7 @@ using namespace Tecs;
 // Instantiate an ECS using our defined World
 static World ecs;
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     { // Start a new transaction with AddRemove permissions to create new entities and components
         auto transaction = ecs.StartTransaction<AddRemove>();
 

--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -24,7 +24,11 @@ namespace Tecs {
     template<typename... Tn>
     class ECS {
     public:
-        ECS() : ecsId(nextEcsId++) {}
+        ECS() {
+#ifndef TECS_HEADER_ONLY
+            ecsId = ++nextEcsId;
+#endif
+        }
 
         template<typename... Permissions>
         /**
@@ -109,7 +113,9 @@ namespace Tecs {
                    ObserverList<Removed<Tn>>...> eventLists;
         // clang-format on
 
+#ifndef TECS_HEADER_ONLY
         size_t ecsId;
+#endif
 
         template<typename, typename...>
         friend class Lock;

--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -106,7 +106,7 @@ namespace Tecs {
 
             int retry = 0;
             while (true) {
-                uint32_t current = readers;
+                current = readers;
                 if (current == READER_FREE) {
                     if (readers.compare_exchange_weak(current, READER_LOCKED)) {
                         // Lock aquired
@@ -151,7 +151,7 @@ namespace Tecs {
                     throw std::runtime_error("WriteUnlock readers changed unexpectedly");
                 }
             }
-    
+
             current = writer;
             if (current != WRITER_LOCKED && current != WRITER_COMMIT) {
                 throw std::runtime_error("WriteUnlock called outside of WriteLock");

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -68,7 +68,7 @@ void renderThread() {
         std::this_thread::sleep_until(lastFrameEnd);
     }
     auto delta = std::chrono::high_resolution_clock::now() - start;
-    double durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
+    size_t durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(delta).count();
     double avgFrameRate = readCount * 1000 / (double)durationMs;
     double avgUpdateRate = currentValue * 1000 / (double)durationMs;
     if (badCount != 0) {
@@ -151,7 +151,7 @@ void transformWorkerThread() {
     }
 }
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     {
         Timer t("Create entities");
         auto writeLock = ecs.StartTransaction<AddRemove>();
@@ -258,7 +258,7 @@ int main(int argc, char **argv) {
         Timer t("Validate entities Tecs");
         int invalid = 0;
         int valid = 0;
-        double commonValue;
+        double commonValue = 0.0;
         auto readLock = ecs.StartTransaction<Read<Transform>>();
         auto &entityList = readLock.EntitiesWith<Transform>();
         for (auto e : entityList) {
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
         Timer t("Validate entities std::vector");
         int invalid = 0;
         int valid = 0;
-        double commonValue;
+        double commonValue = 0.0;
         for (auto &transform : transforms) {
             if (transform.pos[0] != transform.pos[1] || transform.pos[1] != transform.pos[2]) {
                 if (invalid == 0) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -15,7 +15,7 @@ static ECS ecs;
 
 #define ENTITY_COUNT 10000
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     std::cout << "Running with " << ENTITY_COUNT << " entities and " << ecs.GetComponentCount() << " component types"
               << std::endl;
 
@@ -444,7 +444,7 @@ int main(int argc, char **argv) {
         {
             auto writeLock = ecs.StartTransaction<Tecs::AddRemove>();
             e = writeLock.NewEntity();
-            e.Set<Transform>(writeLock, 42.0, 1.0, 64.0, 99.0);
+            e.Set<Transform>(writeLock, 42.0, 1.0, 64.0, 99);
         }
         std::atomic_bool commitStart = false;
         std::atomic_bool commited = false;
@@ -690,9 +690,9 @@ int main(int argc, char **argv) {
 
             while (!commitCompleted) {
                 // Cycle through each transaction and restart the thread when it completes
-                for (auto &t : readThreads) {
-                    t.join();
-                    t = std::thread([] {
+                for (auto &thread : readThreads) {
+                    thread.join();
+                    thread = std::thread([] {
                         auto readLock = ecs.StartTransaction<Tecs::ReadAll>();
                         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     });
@@ -701,8 +701,8 @@ int main(int argc, char **argv) {
         }
 
         blockingThread.join();
-        for (auto &t : readThreads) {
-            t.join();
+        for (auto &thread : readThreads) {
+            thread.join();
         }
     }
     {

--- a/tests/utils.hh
+++ b/tests/utils.hh
@@ -23,13 +23,7 @@ namespace testing {
         MultiTimer(const MultiTimer &) = delete;
 
         MultiTimer() : name(), print(false) {}
-        MultiTimer(std::string name, bool print = true) {
-            Reset(name, print);
-        }
-
-        void Reset(std::string name, bool print = true) {
-            this->name = name;
-            this->print = print;
+        MultiTimer(std::string name, bool print = true) : name(name), print(print) {
             if (print) {
                 std::stringstream ss;
                 ss << "[" << name << "] Start" << std::endl;


### PR DESCRIPTION
- Adds TECS_HEADER_ONLY, which allows header-only use without nested transaction detection.
- Turn on warnings as errors in MSVC with /W4