### PR TITLE
Fix possible deadlock with overlapping transactions on commit

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -6,8 +6,10 @@
 
 #include <Tecs.hh>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <future>
+#include <mutex>
 
 using namespace testing;
 
@@ -568,7 +570,7 @@ int main(int /* argc */, char ** /* argv */) {
                 // Try starting a write transaction while another read transaction is active.
                 auto writeLock = ecs.StartTransaction<Tecs::Write<Script>>();
                 Assert(readId.GetPrevious<Script>(writeLock).data[3] == previousValue,
-                    "Script data should match out read transaction");
+                    "Script data should match read transaction");
 
                 // Commit should not occur since no write operations were done.
                 // Test would otherwise block on commit due to active read transaction.
@@ -590,7 +592,7 @@ int main(int /* argc */, char ** /* argv */) {
                 writeId.Get<Transform>(writeLock).pos[2]++;
 
                 Assert(readId.GetPrevious<Script>(writeLock).data[3] == previousValue,
-                    "Script data should match out read transaction");
+                    "Script data should match read transaction");
 
                 // Commit should only occur on Transform component
                 // Test would otherwise block on Transform commit due to active read transaction.
@@ -610,13 +612,63 @@ int main(int /* argc */, char ** /* argv */) {
                 auto addRemoveLock = ecs.StartTransaction<Tecs::AddRemove>();
 
                 Assert(readId.GetPrevious<Script>(addRemoveLock).data[3] == previousValue,
-                    "Script data should match out read transaction");
+                    "Script data should match read transaction");
 
                 // Commit should not occur since no write operations were done.
                 // Test would otherwise block on commit due to active read transaction.
             });
             readThread.join();
         }
+    }
+    {
+        Timer t("Test overlapping commit transactions don't deadlock");
+        std::thread writeThreadA, writeThreadB;
+        {
+            Tecs::Entity readIdA, readIdB;
+            double previousValueA;
+            uint8_t previousValueB;
+            {
+                auto readLock = ecs.StartTransaction<Tecs::ReadAll>();
+                readIdA = readLock.EntitiesWith<Transform>()[0];
+                readIdB = readLock.EntitiesWith<Script>()[0];
+                previousValueA = readIdA.Get<Transform>(readLock).pos[2];
+                previousValueB = readIdB.Get<Script>(readLock).data[3];
+            }
+
+            int startedThreads = 0;
+            std::mutex mutex;
+            std::condition_variable startedCond;
+
+            // Start both write transactions while another read transaction is active so they commit at the same time.
+            writeThreadA = std::thread([readIdA, previousValueA, &startedThreads, &startedCond, &mutex] {
+                auto writeLock = ecs.StartTransaction<Tecs::Read<Script>, Tecs::Write<Transform>>();
+                auto &transform = readIdA.Get<Transform>(writeLock);
+                Assert(transform.pos[2] == previousValueA, "Transform data should match read transaction");
+                transform.pos[2]++;
+
+                std::unique_lock<std::mutex> lock(mutex);
+                startedThreads++;
+                startedCond.notify_all();
+                startedCond.wait(lock, [&startedThreads] {
+                    return startedThreads == 2;
+                });
+            });
+            writeThreadB = std::thread([readIdB, previousValueB, &startedThreads, &startedCond, &mutex] {
+                auto writeLock = ecs.StartTransaction<Tecs::Read<Transform>, Tecs::Write<Script>>();
+                auto &script = readIdB.Get<Script>(writeLock);
+                Assert(script.data[3] == previousValueB, "Script data should match read transaction");
+                script.data[3]++;
+
+                std::unique_lock<std::mutex> lock(mutex);
+                startedThreads++;
+                startedCond.notify_all();
+                startedCond.wait(lock, [&startedThreads] {
+                    return startedThreads == 2;
+                });
+            });
+        }
+        writeThreadA.join();
+        writeThreadB.join();
     }
     {
         Timer t("Test read with const lock");


### PR DESCRIPTION
This change will unlock all read-only / commit-free components before locking for commit at the end of a transaction.
