### PR TITLE
Add external trace points for transaction start/end

### DIFF
--- a/inc/Tecs_tracing.hh
+++ b/inc/Tecs_tracing.hh
@@ -15,7 +15,27 @@
     #define TECS_PERFORMANCE_TRACING_MAX_EVENTS 10000
 #endif
 
+#ifndef TECS_EXTERNAL_TRACE_TRANSACTION_STARTING
+    #define TECS_EXTERNAL_TRACE_TRANSACTION_STARTING(permissions)
+#endif
+#ifndef TECS_EXTERNAL_TRACE_TRANSACTION_STARTED
+    #define TECS_EXTERNAL_TRACE_TRANSACTION_STARTED(permissions)
+#endif
+#ifndef TECS_EXTERNAL_TRACE_TRANSACTION_ENDING
+    #define TECS_EXTERNAL_TRACE_TRANSACTION_ENDING(permissions)
+#endif
+#ifndef TECS_EXTERNAL_TRACE_TRANSACTION_ENDED
+    #define TECS_EXTERNAL_TRACE_TRANSACTION_ENDED(permissions)
+#endif
+
 namespace Tecs {
+    template<typename... Permissions>
+    struct TransactionPermissions {
+        static constexpr const char *Name() {
+            return __FUNCTION__;
+        }
+    };
+
     struct TraceEvent {
         enum class Type {
             Invalid = 0,

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -82,6 +82,7 @@ namespace Tecs {
     public:
         inline Transaction(ECS<AllComponentTypes...> &instance) : BaseTransaction<ECS, AllComponentTypes...>(instance) {
 #ifdef TECS_ENABLE_PERFORMANCE_TRACING
+            TECS_EXTERNAL_TRACE_TRANSACTION_STARTING(TransactionPermissions<Permissions...>::Name());
             instance.transactionTrace.Trace(TraceEvent::Type::TransactionStart);
 #endif
 
@@ -151,9 +152,16 @@ namespace Tecs {
                     },
                     this->instance.eventLists);
             }
+
+#ifdef TECS_ENABLE_PERFORMANCE_TRACING
+            TECS_EXTERNAL_TRACE_TRANSACTION_STARTED(TransactionPermissions<Permissions...>::Name());
+#endif
         }
 
         inline ~Transaction() {
+#ifdef TECS_ENABLE_PERFORMANCE_TRACING
+            TECS_EXTERNAL_TRACE_TRANSACTION_ENDING(TransactionPermissions<Permissions...>::Name());
+#endif
             if (is_add_remove_allowed<LockType>() && this->writeAccessedFlags[0]) {
                 // Rebuild writeValidEntities, validEntityIndexes, and freeEntities with the new entity set.
                 this->instance.metadata.writeValidEntities.clear();
@@ -216,6 +224,7 @@ namespace Tecs {
             }
 
 #ifdef TECS_ENABLE_PERFORMANCE_TRACING
+            TECS_EXTERNAL_TRACE_TRANSACTION_ENDED(TransactionPermissions<Permissions...>::Name());
             this->instance.transactionTrace.Trace(TraceEvent::Type::TransactionEnd);
 #endif
         }


### PR DESCRIPTION
Allows for inserting a stack allocated trace zone, like Tracy's ScopedZone, or for just recording timings at Start/End.