### PR TITLE
Add UseCount() accessor to Lock

### DIFF
--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -52,7 +52,8 @@ namespace Tecs {
 
     public:
         // Start a new transaction
-        inline Lock(ECS &instance) : instance(instance), base(new Transaction<ECS, Permissions...>(instance)) {
+        inline Lock(ECS &instance) : instance(instance) {
+            base = std::make_shared<Transaction<ECS, Permissions...>>(instance);
             permissions[0] = is_add_remove_allowed<LockType>();
             // clang-format off
             ((
@@ -279,6 +280,10 @@ namespace Tecs {
                 "Lock types are not a subset of existing permissions.");
 
             return Lock<ECS, PermissionsSubset...>(*this);
+        }
+
+        long UseCount() const {
+            return base.use_count();
         }
 
     private:


### PR DESCRIPTION
This makes it possible to check if any code has retained a reference to a lock that was expected to be released at a specific point.