### PR TITLE
Add ECS instance id to entity generations

### DIFF
--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Tecs_entity.hh"
 #include "Tecs_lock.hh"
 #include "Tecs_permissions.hh"
 #include "Tecs_storage.hh"
@@ -73,6 +74,10 @@ namespace Tecs {
             };
         }
 #endif
+
+        inline TECS_ENTITY_ECS_IDENTIFIER_TYPE GetInstanceId() const {
+            return (TECS_ENTITY_ECS_IDENTIFIER_TYPE)ecsId;
+        }
 
         /**
          * Returns the index of a Component type for use in a bitset.

--- a/inc/Tecs_entity.hh
+++ b/inc/Tecs_entity.hh
@@ -15,6 +15,13 @@
     #define TECS_ENTITY_GENERATION_TYPE uint32_t
 #endif
 
+#ifndef TECS_ENTITY_ECS_IDENTIFIER_TYPE
+    #define TECS_ENTITY_ECS_IDENTIFIER_TYPE uint8_t
+#endif
+
+static_assert(sizeof(TECS_ENTITY_GENERATION_TYPE) > sizeof(TECS_ENTITY_ECS_IDENTIFIER_TYPE),
+    "TECS_ENTITY_ECS_IDENTIFIER_TYPE must fit within TECS_ENTITY_GENERATION_TYPE");
+
 namespace Tecs {
     struct Entity;
 };
@@ -24,6 +31,26 @@ namespace std {
 };
 
 namespace Tecs {
+    constexpr TECS_ENTITY_GENERATION_TYPE GenerationWithoutIdentifier(TECS_ENTITY_GENERATION_TYPE generation) {
+        constexpr size_t generationBits =
+            (sizeof(TECS_ENTITY_GENERATION_TYPE) - sizeof(TECS_ENTITY_ECS_IDENTIFIER_TYPE)) * 8;
+        constexpr auto generationMask = ((TECS_ENTITY_GENERATION_TYPE)1 << generationBits) - 1;
+        return generation & generationMask;
+    }
+
+    constexpr TECS_ENTITY_GENERATION_TYPE GenerationWithIdentifier(TECS_ENTITY_GENERATION_TYPE generation,
+        TECS_ENTITY_ECS_IDENTIFIER_TYPE ecsId) {
+        constexpr size_t generationBits =
+            (sizeof(TECS_ENTITY_GENERATION_TYPE) - sizeof(TECS_ENTITY_ECS_IDENTIFIER_TYPE)) * 8;
+        return GenerationWithoutIdentifier(generation) | ((TECS_ENTITY_GENERATION_TYPE)ecsId << generationBits);
+    }
+
+    constexpr TECS_ENTITY_ECS_IDENTIFIER_TYPE IdentifierFromGeneration(TECS_ENTITY_GENERATION_TYPE generation) {
+        constexpr size_t generationBits =
+            (sizeof(TECS_ENTITY_GENERATION_TYPE) - sizeof(TECS_ENTITY_ECS_IDENTIFIER_TYPE)) * 8;
+        return (TECS_ENTITY_ECS_IDENTIFIER_TYPE)(generation >> generationBits);
+    }
+
     struct Entity {
         TECS_ENTITY_GENERATION_TYPE generation;
         TECS_ENTITY_INDEX_TYPE index;
@@ -31,6 +58,9 @@ namespace Tecs {
         inline Entity() : generation(0), index(0) {}
         inline Entity(TECS_ENTITY_INDEX_TYPE index, TECS_ENTITY_GENERATION_TYPE generation)
             : generation(generation), index(index) {}
+        inline Entity(TECS_ENTITY_INDEX_TYPE index, TECS_ENTITY_GENERATION_TYPE generation,
+            TECS_ENTITY_ECS_IDENTIFIER_TYPE ecsId)
+            : generation(GenerationWithIdentifier(generation, ecsId)), index(index) {}
 
     public:
         template<typename LockType>
@@ -275,13 +305,21 @@ namespace std {
     template<>
     struct hash<Tecs::Entity> {
         std::size_t operator()(const Tecs::Entity &e) const {
-            return hash<decltype(e.index)>{}(e.index) ^ (hash<decltype(e.generation)>{}(e.generation) << 1);
+            return hash<TECS_ENTITY_INDEX_TYPE>{}(e.index) ^ (hash<TECS_ENTITY_GENERATION_TYPE>{}(e.generation) << 1);
         }
     };
 
     inline string to_string(const Tecs::Entity &ent) {
         if (ent) {
-            return "Entity(" + to_string(ent.generation) + ", " + to_string(ent.index) + ")";
+            auto ecsId = Tecs::IdentifierFromGeneration(ent.generation);
+            auto generation = Tecs::GenerationWithoutIdentifier(ent.generation);
+            if (ecsId == 1) {
+                // Simplify logging for the common case of 1 ECS instance.
+                return "Entity(gen " + to_string(generation) + ", index " + to_string(ent.index) + ")";
+            } else {
+                return "Entity(ecs " + to_string(ecsId) + ", gen " + to_string(generation) + ", index " +
+                       to_string(ent.index) + ")";
+            }
         } else {
             return "Entity(invalid)";
         }

--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -125,10 +125,11 @@ namespace Tecs {
 
                 // Add all but 1 of the new Entity ids to the free list.
                 for (size_t count = 1; count < TECS_ENTITY_ALLOCATION_BATCH_SIZE; count++) {
-                    instance.freeEntities.emplace_back((TECS_ENTITY_INDEX_TYPE)(nextIndex + count), 1);
+                    instance.freeEntities.emplace_back((TECS_ENTITY_INDEX_TYPE)(nextIndex + count),
+                        1,
+                        (TECS_ENTITY_ECS_IDENTIFIER_TYPE)instance.ecsId);
                 }
-                entity.index = (TECS_ENTITY_INDEX_TYPE)nextIndex;
-                entity.generation = 1;
+                entity = Entity((TECS_ENTITY_INDEX_TYPE)nextIndex, 1, (TECS_ENTITY_ECS_IDENTIFIER_TYPE)instance.ecsId);
             } else {
                 entity = instance.freeEntities.front();
                 instance.freeEntities.pop_front();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -122,7 +122,10 @@ int main(int /* argc */, char ** /* argv */) {
         for (size_t i = 0; i < ENTITY_COUNT; i++) {
             Tecs::Entity e = writeLock.NewEntity();
             Assert(e.index == i, "Expected Nth entity index to be " + std::to_string(i) + ", was " + std::to_string(e));
-            Assert(e.generation == 1, "Expected Nth entity generation to be 1, was " + std::to_string(e));
+            Assert(Tecs::GenerationWithoutIdentifier(e.generation) == 1,
+                "Expected Nth entity generation to be 1, was " + std::to_string(e));
+            Assert(Tecs::IdentifierFromGeneration(e.generation) == 1,
+                "Expected Nth entity ecsId to be 1, was " + std::to_string(e));
             AssertHas<>(writeLock, e);
 
             // Test adding each component type
@@ -174,7 +177,10 @@ int main(int /* argc */, char ** /* argv */) {
             Tecs::Entity e = writeLock.NewEntity();
             Assert(e.index == ENTITY_COUNT + i,
                 "Expected Nth entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " + std::to_string(e));
-            Assert(e.generation == 1, "Expected Nth entity generation to be 1, was " + std::to_string(e));
+            Assert(Tecs::GenerationWithoutIdentifier(e.generation) == 1,
+                "Expected Nth entity generation to be 1, was " + std::to_string(e));
+            Assert(Tecs::IdentifierFromGeneration(e.generation) == 1,
+                "Expected Nth entity ecsId to be 1, was " + std::to_string(e));
             AssertHas<>(writeLock, e);
 
             e.Set<Transform>(writeLock, 1.0, 3.0, 3.0);
@@ -208,7 +214,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(e.index == ENTITY_COUNT + i,
                     "Expected Nth entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(e));
-                Assert(e.generation == 2, "Expected Nth entity generation to be 2, was " + std::to_string(e));
+                Assert(Tecs::GenerationWithoutIdentifier(e.generation) == 2,
+                    "Expected Nth entity generation to be 2, was " + std::to_string(e));
+                Assert(Tecs::IdentifierFromGeneration(e.generation) == 1,
+                    "Expected Nth entity ecsId to be 1, was " + std::to_string(e));
                 AssertHas<>(writeLock, e);
 
                 entityList.emplace_back(e);
@@ -243,7 +252,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(e.index == ENTITY_COUNT + i,
                     "Expected Nth entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(e));
-                Assert(e.generation == 3, "Expected Nth entity generation to be 3, was " + std::to_string(e));
+                Assert(Tecs::GenerationWithoutIdentifier(e.generation) == 3,
+                    "Expected Nth entity generation to be 3, was " + std::to_string(e));
+                Assert(Tecs::IdentifierFromGeneration(e.generation) == 1,
+                    "Expected Nth entity ecsId to be 1, was " + std::to_string(e));
                 AssertHas<>(writeLock, e);
 
                 entityList.emplace_back(e);
@@ -330,8 +342,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.type == Tecs::EventType::ADDED, "Expected entity event type to be ADDED");
                 Assert(event.entity.index == i,
                     "Expected Entity index to be " + std::to_string(i) + ", was " + std::to_string(event.entity));
-                Assert(event.entity.generation == 1,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 1,
                     "Expected Entity generation to be 1, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
             }
             for (size_t i = 0; i < 100; i++) {
                 Assert(entityObserver.Poll(readLock, event),
@@ -340,8 +354,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 2,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 2,
                     "Expected Entity generation to be 2, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
             }
             for (size_t i = 0; i < 100; i++) {
                 Assert(entityObserver.Poll(readLock, event),
@@ -350,8 +366,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 2,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 2,
                     "Expected Entity generation to be 2, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
             }
             for (size_t i = 0; i < 100; i++) {
                 Assert(entityObserver.Poll(readLock, event),
@@ -360,8 +378,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 3,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 3,
                     "Expected Entity generation to be 3, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
             }
             for (size_t i = 0; i < 100; i++) {
                 Assert(entityObserver.Poll(readLock, event),
@@ -370,8 +390,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 3,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 3,
                     "Expected Entity generation to be 3, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
             }
             Assert(!entityObserver.Poll(readLock, event), "Too many events triggered");
         }
@@ -382,8 +404,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.type == Tecs::EventType::ADDED, "Expected component event type to be ADDED");
                 Assert(event.entity.index == i,
                     "Expected Entity index to be " + std::to_string(i) + ", was " + std::to_string(event.entity));
-                Assert(event.entity.generation == 1,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 1,
                     "Expected Entity generation to be 1, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
                 Assert(event.component == Transform(0.0, 0.0, 0.0), "Expected component to be origin transform");
             }
             for (size_t i = 0; i < 100; i++) {
@@ -393,8 +417,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 2,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 2,
                     "Expected Entity generation to be 2, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
                 Assert(event.component == Transform(3.0, 1.0, 7.0), "Expected component to be initial transform");
             }
             for (size_t i = 0; i < 100; i++) {
@@ -403,8 +429,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 2,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 2,
                     "Expected Entity generation to be 2, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
                 Assert(event.component == Transform(3.0, 1.0, 7.0), "Expected renderable name to be updated transform");
             }
             for (size_t i = 0; i < 100; i++) {
@@ -414,8 +442,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 3,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 3,
                     "Expected Entity generation to be 3, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
                 Assert(event.component == Transform(3.0, 1.0, 7.0), "Expected component to be initial transform");
             }
             for (size_t i = 0; i < 100; i++) {
@@ -424,8 +454,10 @@ int main(int /* argc */, char ** /* argv */) {
                 Assert(event.entity.index == ENTITY_COUNT + i,
                     "Expected Entity index to be " + std::to_string(ENTITY_COUNT + i) + ", was " +
                         std::to_string(event.entity));
-                Assert(event.entity.generation == 3,
+                Assert(Tecs::GenerationWithoutIdentifier(event.entity.generation) == 3,
                     "Expected Entity generation to be 3, was " + std::to_string(event.entity));
+                Assert(Tecs::IdentifierFromGeneration(event.entity.generation) == 1,
+                    "Expected Entity ecsId to be 1, was " + std::to_string(event.entity));
                 Assert(event.component == Transform(3.0, 1.0, 7.0), "Expected renderable name to be updated transform");
             }
             Assert(!transformObserver.Poll(readLock, event), "Too many events triggered");


### PR DESCRIPTION
By storing the ecsId in the top bits of each Entity's generation, reusing an Entity from a different ECS instance will result in a missing entity rather than undefined / random entity access.