### PR TITLE
Fix support for Tecs::Entity as an ordered map key

### DIFF
--- a/inc/Tecs_entity.hh
+++ b/inc/Tecs_entity.hh
@@ -289,7 +289,7 @@ namespace Tecs {
         }
 
         inline bool operator<(const Entity &other) const {
-            return index < other.index;
+            return (index == other.index) ? (generation < other.generation) : (index < other.index);
         }
 
         inline bool operator!() const {
@@ -308,7 +308,9 @@ namespace std {
     template<>
     struct hash<Tecs::Entity> {
         std::size_t operator()(const Tecs::Entity &e) const {
-            return hash<TECS_ENTITY_INDEX_TYPE>{}(e.index) ^ (hash<TECS_ENTITY_GENERATION_TYPE>{}(e.generation) << 1);
+            const auto genBits = sizeof(TECS_ENTITY_GENERATION_TYPE) * 8;
+            uint64_t value = (uint64_t)e.index << genBits | e.generation;
+            return hash<uint64_t>{}(value);
         }
     };
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -9,6 +9,7 @@
 #include <condition_variable>
 #include <cstring>
 #include <future>
+#include <map>
 #include <mutex>
 
 using namespace testing;
@@ -1077,6 +1078,20 @@ int main(int /* argc */, char ** /* argv */) {
             for (auto &e : lock.Entities()) {
                 e.Destroy(lock);
             }
+        }
+    }
+    {
+        Timer t("Entities can be ordered map keys");
+        {
+            std::map<Tecs::Entity, int> theMap;
+
+            auto writeLock = ecs.StartTransaction<Tecs::AddRemove>();
+            Tecs::Entity e = writeLock.NewEntity();
+            theMap[e] = 1;
+            Assert(theMap[e] == 1, "Expected value to be set");
+
+            e.generation++;
+            Assert(theMap[e] == 0, "Expected value to not be set");
         }
     }
 


### PR DESCRIPTION
Also improves the hash function to reduce collision potential.