### PR TITLE
Swap buffer pointers to minimize exclusive read lock time

### DIFF
--- a/inc/Tecs_tracing.hh
+++ b/inc/Tecs_tracing.hh
@@ -48,6 +48,7 @@ namespace Tecs {
             WriteLock,
             CommitLockWait,
             CommitLock,
+            CommitUnlock,
             WriteUnlock,
         };
 
@@ -68,6 +69,7 @@ namespace Tecs {
             "WriteLock",
             "CommitLockWait",
             "CommitLock",
+            "CommitUnlock",
             "WriteUnlock",
         };
         return out << eventTypeNames[(size_t)t];

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -176,8 +176,12 @@ int main(int /* argc */, char ** /* argv */) {
     });
 #endif
     {
-        Timer t("Create entities");
+        MultiTimer timer1("Create entities Start");
+        MultiTimer timer2("Create entities Run");
+        MultiTimer timer3("Create entities Commit");
+        Timer t(timer1);
         auto writeLock = ecs.StartTransaction<AddRemove>();
+        t = timer2;
         for (size_t i = 0; i < ENTITY_COUNT; i++) {
             Entity e = writeLock.NewEntity();
             if (i % TRANSFORM_DIVISOR == 0) { e.Set<Transform>(writeLock, 0.0, 0.0, 0.0); }
@@ -186,6 +190,7 @@ int main(int /* argc */, char ** /* argv */) {
                 e.Set<Script>(writeLock, std::initializer_list<uint8_t>({0, 0, 0, 0, 0, 0, 0, 0}));
             }
         }
+        t = timer3;
     }
 
     struct RemovedEntity {


### PR DESCRIPTION
Previously a full buffer copy was happening while holding an exclusive read lock for a component.
This change does a pointer swap, read unlock, and then the copy operation to update the write components with only a write lock.

The Benchmark RenderThread now spends almost no time blocking, with the linux server benchmark blocking time going from 5000ms to ~5ms out of a 10 second test.