### PR TITLE
Better commit locks

### DIFF
--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -245,10 +245,10 @@ namespace Tecs {
 
             // Unlock read copies immediately after commit completion
             uint32_t current = readers;
-            if (current == READER_LOCKED) {
-                if (!readers.compare_exchange_strong(current, READER_FREE)) {
-                    throw std::runtime_error("CommitUnlock readers changed unexpectedly");
-                }
+            if (current != READER_LOCKED) {
+                throw std::runtime_error("CommitUnlock called outside of CommitLock");
+            } else if (!readers.compare_exchange_strong(current, READER_FREE)) {
+                throw std::runtime_error("CommitUnlock readers changed unexpectedly");
             }
 #if __cpp_lib_atomic_wait
             readers.notify_all();

--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -268,38 +268,6 @@ namespace Tecs {
 #endif
         }
 
-        /**
-         * Swaps the read and write buffers and copies any changes so the read and write buffers match.
-         * This should only be called once between CommitLock() and WriteUnlock().
-         * The valid entity list is only copied if AllowAddRemove is true.
-         *
-         * This function will automatically call CommitUnlock().
-         */
-        template<bool AllowAddRemove>
-        inline void CommitEntities() {
-            if (AllowAddRemove) {
-                // The number of components, or list of valid entities may have changed.
-                readComponents.swap(writeComponents);
-                readValidEntities.swap(writeValidEntities);
-                CommitUnlock();
-
-                writeComponents = readComponents;
-                writeValidEntities = readValidEntities;
-            } else {
-                readComponents.swap(writeComponents);
-                CommitUnlock();
-
-                // Based on benchmarks, it is faster to bulk copy if more than roughly 1/6 of the components are valid.
-                if (readValidEntities.size() > writeComponents.size() / 6) {
-                    writeComponents = readComponents;
-                } else {
-                    for (auto &valid : readValidEntities) {
-                        writeComponents[valid.index] = readComponents[valid.index];
-                    }
-                }
-            }
-        }
-
         inline void WriteUnlock() {
 #ifdef TECS_ENABLE_PERFORMANCE_TRACING
             traceInfo.Trace(TraceEvent::Type::WriteUnlock);

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -308,7 +308,7 @@ namespace Tecs {
                         } else {
                             // Based on benchmarks, it is faster to bulk copy if more than roughly 1/6 of the components
                             // are valid.
-                            if (storage.readValidEntities.size() > storage.writeComponents.size() / 6) {
+                            if (storage.readValidEntities.size() > storage.readComponents.size() / 6) {
                                 storage.writeComponents = storage.readComponents;
                             } else {
                                 for (auto &valid : storage.readValidEntities) {

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -266,8 +266,16 @@ namespace Tecs {
 #endif
                 // Swap read and write storage for all held commit locks
                 if (is_add_remove_allowed<LockType>() && this->writeAccessedFlags[0]) {
+                    // Commit observers
+                    std::apply(
+                        [](auto &...args) {
+                            (args.Commit(), ...);
+                        },
+                        this->instance.eventLists);
+
                     this->instance.metadata.readComponents.swap(this->instance.metadata.writeComponents);
                     this->instance.metadata.readValidEntities.swap(this->instance.metadata.writeValidEntities);
+                    this->instance.globalReadMetadata = this->instance.globalWriteMetadata;
                     this->instance.metadata.CommitUnlock();
                 }
                 ( // For each AllComponentTypes
@@ -313,14 +321,6 @@ namespace Tecs {
                 }(),
                 ...);
             if (is_add_remove_allowed<LockType>() && this->writeAccessedFlags[0]) {
-                // Commit observers
-                std::apply(
-                    [](auto &...args) {
-                        (args.Commit(), ...);
-                    },
-                    this->instance.eventLists);
-
-                this->instance.globalReadMetadata = this->instance.globalWriteMetadata;
                 this->instance.metadata.writeComponents = this->instance.metadata.readComponents;
                 this->instance.metadata.writeValidEntities = this->instance.metadata.readValidEntities;
             }

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -197,7 +197,7 @@ namespace Tecs {
             }
 
             ( // For each AllComponentTypes, unlock any Noop Writes or Read locks early
-                [this] {
+                [&] {
                     if constexpr (is_write_allowed<AllComponentTypes, LockType>()) {
                         if (!this->instance.template BitsetHas<AllComponentTypes>(this->writeAccessedFlags)) {
                             this->instance.template Storage<AllComponentTypes>().WriteUnlock();
@@ -216,7 +216,7 @@ namespace Tecs {
                     if (this->writeAccessedFlags[0]) this->instance.metadata.CommitLock();
                 }
                 ( // For each AllComponentTypes
-                    [this] {
+                    [&] {
                         if constexpr (is_write_allowed<AllComponentTypes, LockType>()) {
                             if (this->instance.template BitsetHas<AllComponentTypes>(this->writeAccessedFlags)) {
                                 this->instance.template Storage<AllComponentTypes>().CommitLock();
@@ -245,7 +245,7 @@ namespace Tecs {
                     }
                 }
                 ( // For each AllComponentTypes
-                    [this] {
+                    [&] {
                         if constexpr (is_write_allowed<AllComponentTypes, LockType>()) {
                             // Skip if no write accesses were made
                             if (!this->instance.template BitsetHas<AllComponentTypes>(this->writeAccessedFlags)) return;
@@ -264,7 +264,7 @@ namespace Tecs {
             }
 
             ( // For each AllComponentTypes, reset the write storage to match read.
-                [this] {
+                [&] {
                     if constexpr (is_write_allowed<AllComponentTypes, LockType>()) {
                         // Skip if no write accesses were made
                         if (!this->instance.template BitsetHas<AllComponentTypes>(this->writeAccessedFlags)) return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,22 +1,27 @@
 add_executable(${PROJECT_NAME}-benchmark benchmark.cpp transform_component.cpp)
 target_link_libraries(${PROJECT_NAME}-benchmark ${PROJECT_NAME})
 target_compile_definitions(${PROJECT_NAME}-benchmark PRIVATE TECS_ENABLE_PERFORMANCE_TRACING)
-
-set(TRACY_NO_EXIT ON CACHE BOOL "" FORCE)
-set(TRACY_ONLY_LOCALHOST ON CACHE BOOL "" FORCE)
-add_subdirectory(tracy)
-if(UNIX)
-target_compile_options(TracyClient PRIVATE -Wno-unused-private-field)
-endif()
-
-add_executable(${PROJECT_NAME}-benchmark-tracy benchmark.cpp transform_component.cpp)
-target_link_libraries(${PROJECT_NAME}-benchmark-tracy ${PROJECT_NAME} TracyClient)
-target_compile_definitions(${PROJECT_NAME}-benchmark-tracy PRIVATE TECS_ENABLE_TRACY)
-
 if(WIN32)
     # Link winmm library for timeBeginPeriod()
     target_link_libraries(${PROJECT_NAME}-benchmark winmm)
-    target_link_libraries(${PROJECT_NAME}-benchmark-tracy winmm)
+endif()
+
+# Only build the tracy benchmark if the submodule is populated
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tracy/CMakeLists.txt)
+    set(TRACY_NO_EXIT ON CACHE BOOL "" FORCE)
+    set(TRACY_ONLY_LOCALHOST ON CACHE BOOL "" FORCE)
+    add_subdirectory(tracy)
+    if(UNIX)
+        target_compile_options(TracyClient PRIVATE -Wno-unused-private-field)
+    endif()
+
+    add_executable(${PROJECT_NAME}-benchmark-tracy benchmark.cpp transform_component.cpp)
+    target_link_libraries(${PROJECT_NAME}-benchmark-tracy ${PROJECT_NAME} TracyClient)
+    target_compile_definitions(${PROJECT_NAME}-benchmark-tracy PRIVATE TECS_ENABLE_TRACY)
+    if(WIN32)
+        # Link winmm library for timeBeginPeriod()
+        target_link_libraries(${PROJECT_NAME}-benchmark-tracy winmm)
+    endif()
 endif()
 
 add_executable(${PROJECT_NAME}-tests tests.cpp transform_component.cpp)


### PR DESCRIPTION
Reduces the amount of time spent in the critical commit lock section when committing multi-component transaction writes.
The storage pointer swap is now nearly instant, and the majority of is now spent acquiring the lock (waiting for readers to finish before committing).
Since the benchmark only contains single-component transactions, this particular lock contention is not measured unless modified to include Script components.

Also fixes CMake to allow building without the Tracy submodule checked out.