### PR TITLE
Entity metadata race fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     },
     "C_Cpp.files.exclude": {
         "tests/tracy/server/": true
-    }
+    },
+    "C_Cpp.autoAddFileAssociations": false
 }

--- a/inc/Tecs_entity.hh
+++ b/inc/Tecs_entity.hh
@@ -181,11 +181,13 @@ namespace Tecs {
             static_assert(!is_global_component<T>(), "Global components must be accessed through lock.Set()");
             lock.base->template SetAccessFlag<T>(true);
 
-            if (index >= lock.instance.metadata.writeComponents.size()) {
+            auto &metadataList =
+                lock.permissions[0] ? lock.instance.metadata.writeComponents : lock.instance.metadata.readComponents;
+            if (index >= metadataList.size()) {
                 throw std::runtime_error("Entity does not exist: " + std::to_string(*this));
             }
 
-            auto &metadata = lock.instance.metadata.writeComponents[index];
+            auto &metadata = metadataList[index];
             if (!metadata[0] || metadata.generation != generation) {
                 throw std::runtime_error("Entity does not exist: " + std::to_string(*this));
             }
@@ -212,11 +214,13 @@ namespace Tecs {
             static_assert(!is_global_component<T>(), "Global components must be accessed through lock.Set()");
             lock.base->template SetAccessFlag<T>(true);
 
-            if (index >= lock.instance.metadata.writeComponents.size()) {
+            auto &metadataList =
+                lock.permissions[0] ? lock.instance.metadata.writeComponents : lock.instance.metadata.readComponents;
+            if (index >= metadataList.size()) {
                 throw std::runtime_error("Entity does not exist: " + std::to_string(*this));
             }
 
-            auto &metadata = lock.instance.metadata.writeComponents[index];
+            auto &metadata = metadataList[index];
             if (!metadata[0] || metadata.generation != generation) {
                 throw std::runtime_error("Entity does not exist: " + std::to_string(*this));
             }


### PR DESCRIPTION
Fixes an issue with `entity.Set<>()` using the wrong copy of the metadata in some situations, including a new regression test.
Also adjusts the atomic memory_order for storage locks to be slightly more optimal.