### PR TITLE
`DynamicLock<>` type for runtime permission checking

### DIFF
--- a/inc/Tecs.hh
+++ b/inc/Tecs.hh
@@ -106,6 +106,14 @@ namespace Tecs {
             }
         }
 
+        /**
+         * Returns true if the Component type is part of this ECS.
+         */
+        template<typename U>
+        inline static constexpr bool IsComponent() {
+            return contains<U, Tn...>();
+        }
+
         inline static constexpr size_t GetBytesPerEntity() {
             return (ComponentIndex<Tn>::GetBytesPerEntity() + ...);
         }

--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -97,6 +97,12 @@ namespace Tecs {
             return instance;
         }
 
+#ifndef TECS_HEADER_ONLY
+        inline size_t GetTransactionId() const {
+            return base->transactionId;
+        }
+#endif
+
         template<typename T>
         inline const EntityView PreviousEntitiesWith() const {
             static_assert(!is_global_component<T>(), "Entities can't have global components");

--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -71,18 +71,25 @@ namespace Tecs {
             // clang-format on
         }
 
+        // Returns true if this lock type can be constructed from a lock with the specified source permissions
         template<typename... PermissionsSource>
-        static constexpr bool has_all_permissions() {
+        static constexpr bool is_lock_subset() {
             using SourceLockType = Lock<ECS, PermissionsSource...>;
             if constexpr (is_add_remove_allowed<LockType>() && !is_add_remove_allowed<SourceLockType>()) {
                 return false;
             } else {
-                return std::conjunction<is_lock_subset<AllComponentTypes, LockType, SourceLockType>...>();
+                return std::conjunction<Tecs::is_lock_subset<AllComponentTypes, LockType, SourceLockType>...>();
             }
         }
 
+        // Returns true if this lock type has all of the requested permissions
+        template<typename... RequestedPermissions>
+        static constexpr bool has_permissions() {
+            return Lock<ECS, RequestedPermissions...>::template is_lock_subset<LockType>();
+        }
+
         // Reference an existing transaction
-        template<typename... PermissionsSource, std::enable_if_t<has_all_permissions<PermissionsSource...>(), int> = 0>
+        template<typename... PermissionsSource, std::enable_if_t<is_lock_subset<PermissionsSource...>(), int> = 0>
         inline Lock(const Lock<ECS, PermissionsSource...> &source)
             : instance(source.instance), base(source.base), permissions(source.permissions) {}
 
@@ -293,10 +300,7 @@ namespace Tecs {
         template<typename... PermissionsSubset>
         inline Lock<ECS, PermissionsSubset...> Subset() const {
             using NewLockType = Lock<ECS, PermissionsSubset...>;
-            static_assert(is_add_remove_allowed<LockType>() || !is_add_remove_allowed<NewLockType>(),
-                "AddRemove permission is missing.");
-            static_assert(std::conjunction<is_lock_subset<AllComponentTypes, NewLockType, LockType>...>(),
-                "Lock types are not a subset of existing permissions.");
+            static_assert(has_permissions<NewLockType>(), "Lock types are not a subset of existing permissions.");
 
             return Lock<ECS, PermissionsSubset...>(*this);
         }
@@ -367,31 +371,40 @@ namespace Tecs {
     private:
         using ECS = ECSType<AllComponentTypes...>;
 
-        std::bitset<1 + sizeof...(AllComponentTypes)> readPermissions;
+        const std::bitset<1 + sizeof...(AllComponentTypes)> readPermissions;
+
+        template<typename... Permissions>
+        static const auto generateReadBitset() {
+            std::bitset<1 + sizeof...(AllComponentTypes)> result;
+            result[0] = true;
+            ((result[1 + ECS::template GetComponentIndex<AllComponentTypes>()] =
+                     is_read_allowed<AllComponentTypes, Permissions...>()),
+                ...);
+            return result;
+        }
+
+        template<typename... Permissions>
+        static const auto generateWriteBitset() {
+            std::bitset<1 + sizeof...(AllComponentTypes)> result;
+            result[0] = Tecs::is_add_remove_allowed<Permissions...>();
+            ((result[1 + ECS::template GetComponentIndex<AllComponentTypes>()] =
+                     is_write_allowed<AllComponentTypes, Permissions...>()),
+                ...);
+            return result;
+        }
 
     public:
         template<typename LockType>
-        DynamicLock(const LockType &lock) : Lock<ECS, StaticPermissions...>(lock) {
-            readPermissions[0] = true;
-            ((readPermissions[1 + this->instance.template GetComponentIndex<AllComponentTypes>()] =
-                     is_read_allowed<AllComponentTypes, LockType>()),
-                ...);
-        }
+        DynamicLock(const LockType &lock)
+            : Lock<ECS, StaticPermissions...>(lock), readPermissions(generateReadBitset<LockType>()) {}
 
         template<typename... DynamicPermissions>
         std::optional<Lock<ECS, DynamicPermissions...>> TryLock() const {
-            if constexpr (Lock<ECS, DynamicPermissions...>::template has_all_permissions<StaticPermissions...>()) {
+            if constexpr (Lock<ECS, StaticPermissions...>::template has_permissions<DynamicPermissions...>()) {
                 return Lock<ECS, DynamicPermissions...>(this->instance, this->base, this->permissions);
             } else {
-                std::bitset<1 + sizeof...(AllComponentTypes)> requestedRead, requestedWrite;
-                requestedRead[0] = true;
-                requestedWrite[1] = Tecs::is_add_remove_allowed<DynamicPermissions...>();
-                ((requestedRead[1 + this->instance.template GetComponentIndex<AllComponentTypes>()] =
-                         is_read_allowed<AllComponentTypes, DynamicPermissions...>()),
-                    ...);
-                ((requestedWrite[1 + this->instance.template GetComponentIndex<AllComponentTypes>()] =
-                         is_write_allowed<AllComponentTypes, DynamicPermissions...>()),
-                    ...);
+                static const auto requestedRead = generateReadBitset<DynamicPermissions...>();
+                static const auto requestedWrite = generateWriteBitset<DynamicPermissions...>();
                 if ((requestedRead & readPermissions) == requestedRead &&
                     (requestedWrite & this->permissions) == requestedWrite) {
                     return Lock<ECS, DynamicPermissions...>(this->instance, this->base, this->permissions);

--- a/inc/Tecs_permissions.hh
+++ b/inc/Tecs_permissions.hh
@@ -11,6 +11,8 @@ namespace Tecs {
     template<typename, typename...>
     class Lock {};
     template<typename, typename...>
+    class DynamicLock {};
+    template<typename, typename...>
     class Transaction {};
 
     /**
@@ -108,22 +110,34 @@ namespace Tecs {
     template<typename Lock>
     struct is_add_remove_allowed : std::false_type {};
 
-    // Lock<Permissions...> specializations
+    // Lock<Permissions...> and DynamicLock<Permissions...> specializations
     // clang-format off
     template<typename T, typename ECSType, typename... Permissions>
     struct is_read_allowed<T, Lock<ECSType, Permissions...>> : std::disjunction<is_read_allowed<T, Permissions>...> {};
     template<typename T, typename ECSType, typename... Permissions>
     struct is_read_allowed<T, const Lock<ECSType, Permissions...>> : std::disjunction<is_read_allowed<T, Permissions>...> {};
+    template<typename T, typename ECSType, typename... Permissions>
+    struct is_read_allowed<T, DynamicLock<ECSType, Permissions...>> : std::disjunction<is_read_allowed<T, Permissions>...> {};
+    template<typename T, typename ECSType, typename... Permissions>
+    struct is_read_allowed<T, const DynamicLock<ECSType, Permissions...>> : std::disjunction<is_read_allowed<T, Permissions>...> {};
 
     template<typename T, typename ECSType, typename... Permissions>
     struct is_write_allowed<T, Lock<ECSType, Permissions...>> : std::disjunction<is_write_allowed<T, Permissions>...> {};
     template<typename T, typename ECSType, typename... Permissions>
     struct is_write_allowed<T, const Lock<ECSType, Permissions...>> : std::disjunction<is_write_allowed<T, Permissions>...> {};
+    template<typename T, typename ECSType, typename... Permissions>
+    struct is_write_allowed<T, DynamicLock<ECSType, Permissions...>> : std::disjunction<is_write_allowed<T, Permissions>...> {};
+    template<typename T, typename ECSType, typename... Permissions>
+    struct is_write_allowed<T, const DynamicLock<ECSType, Permissions...>> : std::disjunction<is_write_allowed<T, Permissions>...> {};
 
     template<typename ECSType, typename... Permissions>
     struct is_add_remove_allowed<Lock<ECSType, Permissions...>> : contains<AddRemove, Permissions...> {};
     template<typename ECSType, typename... Permissions>
     struct is_add_remove_allowed<const Lock<ECSType, Permissions...>> : contains<AddRemove, Permissions...> {};
+    template<typename ECSType, typename... Permissions>
+    struct is_add_remove_allowed<DynamicLock<ECSType, Permissions...>> : contains<AddRemove, Permissions...> {};
+    template<typename ECSType, typename... Permissions>
+    struct is_add_remove_allowed<const DynamicLock<ECSType, Permissions...>> : contains<AddRemove, Permissions...> {};
     // clang-format on
 
     // Check SubLock <= Lock for component type T

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -27,6 +27,7 @@ namespace Tecs {
     extern thread_local std::array<size_t, TECS_MAX_ACTIVE_TRANSACTIONS_PER_THREAD> activeTransactions;
     extern thread_local size_t activeTransactionsCount;
     extern std::atomic_size_t nextEcsId;
+    extern std::atomic_size_t nextTransactionId;
 #endif
 
     /**
@@ -41,6 +42,7 @@ namespace Tecs {
     public:
         BaseTransaction(ECSType<AllComponentTypes...> &instance) : instance(instance) {
 #ifndef TECS_HEADER_ONLY
+            transactionId = ++nextTransactionId;
             for (size_t i = 0; i < activeTransactionsCount; i++) {
                 if (activeTransactions[i] == instance.ecsId)
                     throw std::runtime_error("Nested transactions are not allowed");
@@ -64,6 +66,9 @@ namespace Tecs {
 
     protected:
         ECSType<AllComponentTypes...> &instance;
+#ifndef TECS_HEADER_ONLY
+        size_t transactionId;
+#endif
 
         std::bitset<1 + sizeof...(AllComponentTypes)> writeAccessedFlags;
 

--- a/src/Tecs.cc
+++ b/src/Tecs.cc
@@ -5,4 +5,5 @@ namespace Tecs {
     thread_local std::array<size_t, TECS_MAX_ACTIVE_TRANSACTIONS_PER_THREAD> activeTransactions;
     thread_local size_t activeTransactionsCount = 0;
     std::atomic_size_t nextEcsId(0);
+    std::atomic_size_t nextTransactionId(0);
 } // namespace Tecs


### PR DESCRIPTION
This new type allows a bit more flexibility for passing locks around with optional permissions:

```cpp
std::optional<Lock<ECS, RuntimePermissions...>> DynamicLock<ECS, StaticPermissions...>::TryLock<RuntimePermissions...>();
```

Locks also now provide a global transactionId that can be used for synchronization with other code such as application like event queues.