### PR TITLE
Entity access tracking

### DIFF
--- a/inc/Tecs_entity.hh
+++ b/inc/Tecs_entity.hh
@@ -122,7 +122,7 @@ namespace Tecs {
                 "Can't get non-const reference of read only Component.");
             static_assert(!is_global_component<CompType>(), "Global components must be accessed through lock.Get()");
 
-            if constexpr (!std::is_const<ReturnType>()) lock.base->template SetAccessFlag<CompType>(true);
+            if constexpr (!std::is_const<ReturnType>()) lock.base->template SetAccessFlag<CompType>(index);
 
 #ifndef TECS_UNCHECKED_MODE
             auto &metadataList =
@@ -198,7 +198,7 @@ namespace Tecs {
         inline T &Set(const LockType &lock, T &value) const {
             static_assert(is_write_allowed<T, LockType>(), "Component is not locked for writing.");
             static_assert(!is_global_component<T>(), "Global components must be accessed through lock.Set()");
-            lock.base->template SetAccessFlag<T>(true);
+            lock.base->template SetAccessFlag<T>(index);
 
 #ifndef TECS_UNCHECKED_MODE
             auto &metadataList =
@@ -239,7 +239,7 @@ namespace Tecs {
         inline T &Set(const LockType &lock, Args... args) const {
             static_assert(is_write_allowed<T, LockType>(), "Component is not locked for writing.");
             static_assert(!is_global_component<T>(), "Global components must be accessed through lock.Set()");
-            lock.base->template SetAccessFlag<T>(true);
+            lock.base->template SetAccessFlag<T>(index);
 
 #ifndef TECS_UNCHECKED_MODE
             auto &metadataList =

--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -154,6 +154,7 @@ namespace Tecs {
                 instance.metadata.writeComponents.resize(newSize);
                 instance.metadata.validEntityIndexes.resize(newSize);
                 instance.metadata.writeAccessedEntities.resize(newSize, true);
+                instance.metadata.writeAccessedCount += TECS_ENTITY_ALLOCATION_BATCH_SIZE;
 
                 // Add all but 1 of the new Entity ids to the free list.
                 for (size_t count = 1; count < TECS_ENTITY_ALLOCATION_BATCH_SIZE; count++) {
@@ -172,7 +173,10 @@ namespace Tecs {
             auto &validEntities = instance.metadata.writeValidEntities;
             instance.metadata.validEntityIndexes[entity.index] = validEntities.size();
             validEntities.emplace_back(entity);
-            instance.metadata.writeAccessedEntities[entity.index] = true;
+            if (!instance.metadata.writeAccessedEntities[entity.index]) {
+                instance.metadata.writeAccessedEntities[entity.index] = true;
+                instance.metadata.writeAccessedCount++;
+            }
 
             return entity;
         }
@@ -366,6 +370,7 @@ namespace Tecs {
                 storage.writeComponents.resize(newSize);
                 storage.validEntityIndexes.resize(newSize);
                 storage.writeAccessedEntities.resize(newSize, true);
+                storage.writeAccessedCount += count;
             } else {
                 (void)count; // Unreferenced parameter warning on MSVC
             }

--- a/inc/Tecs_lock.hh
+++ b/inc/Tecs_lock.hh
@@ -153,11 +153,10 @@ namespace Tecs {
                 }
                 instance.metadata.writeComponents.resize(newSize);
                 instance.metadata.validEntityIndexes.resize(newSize);
-                instance.metadata.writeAccessedEntities.resize(newSize, true);
-                instance.metadata.writeAccessedCount += TECS_ENTITY_ALLOCATION_BATCH_SIZE;
 
                 // Add all but 1 of the new Entity ids to the free list.
                 for (size_t count = 1; count < TECS_ENTITY_ALLOCATION_BATCH_SIZE; count++) {
+                    instance.metadata.AccessEntity(nextIndex + count);
                     instance.freeEntities.emplace_back((TECS_ENTITY_INDEX_TYPE)(nextIndex + count),
                         1,
                         (TECS_ENTITY_ECS_IDENTIFIER_TYPE)instance.ecsId);
@@ -173,10 +172,7 @@ namespace Tecs {
             auto &validEntities = instance.metadata.writeValidEntities;
             instance.metadata.validEntityIndexes[entity.index] = validEntities.size();
             validEntities.emplace_back(entity);
-            if (!instance.metadata.writeAccessedEntities[entity.index]) {
-                instance.metadata.writeAccessedEntities[entity.index] = true;
-                instance.metadata.writeAccessedCount++;
-            }
+            instance.metadata.AccessEntity(entity.index);
 
             return entity;
         }
@@ -369,8 +365,6 @@ namespace Tecs {
                 size_t newSize = storage.writeComponents.size() + count;
                 storage.writeComponents.resize(newSize);
                 storage.validEntityIndexes.resize(newSize);
-                storage.writeAccessedEntities.resize(newSize, true);
-                storage.writeAccessedCount += count;
             } else {
                 (void)count; // Unreferenced parameter warning on MSVC
             }

--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -333,12 +333,6 @@ namespace Tecs {
 
         inline void AccessEntity(size_t index) {
             writeAccessedEntities.emplace_back(index);
-
-            // Deduplicate and sort the access list
-            // auto it = std::lower_bound(writeAccessedEntities.begin(), writeAccessedEntities.end(), index);
-            // if (it == writeAccessedEntities.end() || *it != index) {
-            //     writeAccessedEntities.insert(it, index);
-            // }
         }
 
     private:

--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -155,6 +155,7 @@ namespace Tecs {
 #endif
 
                         // Reset access flags
+                        writeAccessedCount = 0;
                         writeAccessedEntities.clear();
                         writeAccessedEntities.resize(writeComponents.size());
                         return true;
@@ -351,6 +352,7 @@ namespace Tecs {
         std::vector<Entity> writeValidEntities;
         std::vector<size_t> validEntityIndexes; // Size of writeComponents, Indexes into writeValidEntities
 
+        size_t writeAccessedCount = 0;
         std::vector<bool> writeAccessedEntities; // Size of writeComponents
 
         template<typename, typename...>

--- a/inc/Tecs_storage.hh
+++ b/inc/Tecs_storage.hh
@@ -153,6 +153,10 @@ namespace Tecs {
                             tracyWrite.AfterTryLock(true);
                         }
 #endif
+
+                        // Reset access flags
+                        writeAccessedEntities.clear();
+                        writeAccessedEntities.resize(writeComponents.size());
                         return true;
                     }
                 }
@@ -345,12 +349,16 @@ namespace Tecs {
         std::vector<T> writeComponents;
         std::vector<Entity> readValidEntities;
         std::vector<Entity> writeValidEntities;
-        std::vector<size_t> validEntityIndexes; // Indexes into writeValidEntities
+        std::vector<size_t> validEntityIndexes; // Size of writeComponents, Indexes into writeValidEntities
+
+        std::vector<bool> writeAccessedEntities; // Size of writeComponents
 
         template<typename, typename...>
         friend class Lock;
         template<typename, typename...>
         friend class Transaction;
+        template<template<typename...> typename, typename...>
+        friend class BaseTransaction;
         friend struct Entity;
     };
 } // namespace Tecs

--- a/inc/Tecs_transaction.hh
+++ b/inc/Tecs_transaction.hh
@@ -299,16 +299,9 @@ namespace Tecs {
                             storage.writeComponents = storage.readComponents;
                             storage.writeValidEntities = storage.readValidEntities;
                         } else {
-                            // Based on benchmarks, it is faster to bulk copy if more than
-                            // roughly 1/6 of the components are valid and the component is trivially copyable.
-                            if (std::is_trivially_copyable<AllComponentTypes>() &&
-                                storage.writeAccessedCount > storage.readComponents.size() / 6) {
-                                storage.writeComponents = storage.readComponents;
-                            } else {
-                                for (auto &valid : storage.readValidEntities) {
-                                    if (storage.writeAccessedEntities[valid.index]) {
-                                        storage.writeComponents[valid.index] = storage.readComponents[valid.index];
-                                    }
+                            for (auto &valid : storage.readValidEntities) {
+                                if (storage.writeAccessedEntities[valid.index]) {
+                                    storage.writeComponents[valid.index] = storage.readComponents[valid.index];
                                 }
                             }
                         }

--- a/tests/utils.hh
+++ b/tests/utils.hh
@@ -14,6 +14,7 @@ namespace testing {
             std::stringstream ss;
             ss << "Assertion failed: " << message << std::endl;
             std::cout << ss.str();
+            __debugbreak();
             throw std::runtime_error(message);
         }
     }

--- a/tests/utils.hh
+++ b/tests/utils.hh
@@ -14,7 +14,6 @@ namespace testing {
             std::stringstream ss;
             ss << "Assertion failed: " << message << std::endl;
             std::cout << ss.str();
-            __debugbreak();
             throw std::runtime_error(message);
         }
     }


### PR DESCRIPTION
This PR updates the component access tracking to include individual entities. This allows transaction commits to only copy the modified components rather than all of them (seeing a 25x speedup on transaction commit in Stray Photons with a 2x overall game logic update rate improvement)

The benchmark now reflects this improvement, but shows a slight overhead increase when modifying every entity in a transaction.